### PR TITLE
MLT-337

### DIFF
--- a/src/app/modules/signatory-progress/utils/formatBarData.ts
+++ b/src/app/modules/signatory-progress/utils/formatBarData.ts
@@ -5,7 +5,7 @@ import { HorizontalBarChartCardModel } from 'app/components/surfaces/Cards/Horiz
 import { SigItemModel, specPubsItemModel } from './intefaces';
 import { SingleDefGBSignatory } from 'app/state/api/interfaces/gbsignatoryInterface';
 /* utils */
-import { getRealSigCount } from './general';
+import { getAllSigCount, getRealSigCount } from './general';
 
 export function formatBarData(
   publisherData: SigItemModel,
@@ -18,6 +18,19 @@ export function formatBarData(
   };
 
   if (publisherData) {
+    // We'll get the all gb signatory count for comparison
+    // here
+    const allSigCount = getAllSigCount(gbsignatories);
+    // getting the latest dateRange key
+    const lastRKey = `orgs_[${dateRanges[dateRanges.length - 1].value}]`;
+    // getting the latest publisher data
+    const lastPubData = publisherData[lastRKey];
+    // We'll push the first bar data item here
+    barData.data.values.push({
+      value: lastPubData.sigCount,
+      percentage: Math.round((lastPubData.sigCount * 100) / allSigCount),
+      name: 'Singatories publishing to IATI',
+    });
     specPubsData.forEach(item => {
       // so here we'll use the latest data for the bar chart
       // and thats why we choose the last item from dateRanges
@@ -39,9 +52,7 @@ export function formatBarData(
         );
         // a simple proportion calculation is applied here
         // to get the percentage value
-        percentage = Math.round(
-          (specSigCount * 100) / publisherData[rangeKey].sigCount
-        );
+        percentage = Math.round((specSigCount * 100) / allSigCount);
 
         value = specSigCount;
       }

--- a/src/app/modules/signatory-progress/utils/formatLineChart.ts
+++ b/src/app/modules/signatory-progress/utils/formatLineChart.ts
@@ -6,7 +6,40 @@ import { DataPoint, SigItemModel, specPubsItemModel } from './intefaces';
 import { SingleDefGBSignatory } from 'app/state/api/interfaces/gbsignatoryInterface';
 
 /* utils */
-import { checkIfValid, getRealSigCount } from './general';
+import { checkIfValid, getAllSigCount, getRealSigCount } from './general';
+
+export interface FirstDataItemModel {
+  data: DataPoint[];
+  totalSigCount: number;
+}
+
+function formatFirstLine(
+  publisherData: SigItemModel,
+  gbsignatories: SingleDefGBSignatory[]
+): FirstDataItemModel {
+  // so first we get the actual amount of GB
+  // signatories
+  const allSigCount = getAllSigCount(gbsignatories);
+  const firstData: DataPoint[] = [];
+  dateRanges.forEach(range => {
+    const rangeKey = `orgs_[${range.value}]`;
+    // a simple proportion calculation is applied here
+    // to get the percentage value
+    const percentage = Math.round(
+      (publisherData[rangeKey].sigCount * 100) / allSigCount
+    );
+
+    firstData.push({
+      x: range.label,
+      y: percentage,
+    });
+  });
+
+  return {
+    data: firstData,
+    totalSigCount: allSigCount,
+  };
+}
 
 export function formatLineChart(
   publisherData: SigItemModel,
@@ -18,10 +51,19 @@ export function formatLineChart(
     values: { values: [] },
   };
 
-  // so this part forms the line 'Publishing hum. activity data'
   if (publisherData) {
+    // first here we form Signatories publishing
+    // to IATI line by comparing
+    const firstDataItem = formatFirstLine(publisherData, gbsignatories);
+    lineData.values.values.push({
+      data: firstDataItem.data,
+      id: 'Signatories publish to IATI',
+    });
+
+    const allSigCount = firstDataItem.totalSigCount;
+
     specPubsData.forEach(item => {
-      const data: Array<DataPoint> = [];
+      const data: DataPoint[] = [];
 
       dateRanges.forEach(range => {
         const rangeKey = `orgs_[${range.value}]`;
@@ -36,9 +78,19 @@ export function formatLineChart(
 
           // a simple proportion calculation is applied here
           // to get the percentage value
-          percentage = Math.round(
-            (specSigCount * 100) / publisherData[rangeKey].sigCount
-          );
+          // This way the specific sig data would be compared to the
+          // Signatories publishing to IATI amount
+          // which would make the linechart make little sense
+          // cause we would have the signatories publishing humanitarian
+          // data have a bigger percentage than the signatories publishing
+          // data to IATI
+          // percentage = Math.round(
+          //   (specSigCount * 100) / publisherData[rangeKey].sigCount
+          // );
+          // so we'll use this percantage proportion instead
+          // we'll compare the flat amount of signatories to all specific data
+          // as that will be more accurate at least line chart wise
+          percentage = Math.round((specSigCount * 100) / allSigCount);
         }
 
         data.push({

--- a/src/app/modules/signatory-progress/utils/formatTableData.ts
+++ b/src/app/modules/signatory-progress/utils/formatTableData.ts
@@ -1,5 +1,5 @@
 import { dateRanges } from 'app/modules/signatory-progress/const';
-import { checkIfValid, getRealSigCount } from './general';
+import { checkIfValid, getAllSigCount, getRealSigCount } from './general';
 import { SigItemModel, specPubsItemModel } from './intefaces';
 import { SingleDefGBSignatory } from '../../../state/api/interfaces/gbsignatoryInterface';
 
@@ -7,20 +7,20 @@ export function formatTableData(
   publisherData: SigItemModel,
   specPubsData: Array<specPubsItemModel>,
   gbsignatories: SingleDefGBSignatory[]
-): Array<Array<string>> {
-  const tableData: Array<Array<string>> = [];
+): Array<Array<string | number>> {
+  const tableData: Array<Array<string | number>> = [];
 
   if (publisherData) {
-    // so here we push in some data for all of the grand bargain
-    // signatories. (Right now we have no data on all of them)
-    // divided by dates, so we just put in N/A
+    // so as discussed we only have a flat amount of them
+    // not associated with dates, so we put them in like so
+    const allSigCount = getAllSigCount(gbsignatories);
     tableData.push([
       'Total no. of Grand Bargain Signatories',
-      'N/A',
-      'N/A',
-      'N/A',
-      'N/A',
-      'N/A',
+      allSigCount,
+      allSigCount,
+      allSigCount,
+      allSigCount,
+      0,
     ]);
 
     tableData.push(['Organisations* publishing to IATI']);
@@ -29,7 +29,12 @@ export function formatTableData(
     // and here we push in the actual values for all the organisations
     dateRanges.forEach((range, index) => {
       const rangeKey = `orgs_[${range.value}]`;
-      tableData[1].push(`100% (${publisherData[rangeKey].sigCount})`);
+      const pubIatiPercent = Math.round(
+        (publisherData[rangeKey].sigCount * 100) / allSigCount
+      );
+      tableData[1].push(
+        `${pubIatiPercent}% (${publisherData[rangeKey].sigCount})`
+      );
       if (index === dateRanges.length - 2) {
         befLastRKey = rangeKey;
       }

--- a/src/app/modules/signatory-progress/utils/general.ts
+++ b/src/app/modules/signatory-progress/utils/general.ts
@@ -39,3 +39,13 @@ export function getRealSigCount(
 
   return realSignatories.length;
 }
+
+export function getAllSigCount(gbsignatories: SingleDefGBSignatory[]): number {
+  const realSigs: string[] = [];
+  gbsignatories.forEach(sigOrg => {
+    if (realSigs.indexOf(sigOrg.name) === -1) {
+      realSigs.push(sigOrg.name);
+    }
+  });
+  return realSigs.length;
+}


### PR DESCRIPTION
https://zimmermanzimmerman.atlassian.net/browse/MLT-337

ONCE PROPER NON IATI SIGNATORY DATA IS PROVIDED - Add 'Signatories publish to IATI' line. Currently[26-08-2019] we have no non-iati signatory data associated with dates, so this lines implementation cannot be done.  So do it when we have this data in our CMS. 

ALSO: Make sure to adjust the data shown in the table according to this total n.o of grand bargain signatories.