### PR TITLE
fix: counts were incorrectly zero for location gazeteers

### DIFF
--- a/src/app/modules/signatory-data/submodules/overview/const.ts
+++ b/src/app/modules/signatory-data/submodules/overview/const.ts
@@ -102,7 +102,7 @@ export const humCallValues = {
   },
   humActWLocationInfoData_3: {
     type: 'query',
-    q: 'location_id_code:*',
+    q: 'location_id_code:* OR location_point_pos:*',
   },
   humActWLocationInfoData_4: {
     type: 'query',


### PR DESCRIPTION
[MLT-843]
[check] Counts are incorrectly zero for 'location according to a recognised geo-location gazetteer'
https://zimmermanzimmerman.atlassian.net/browse/MLT-843

So tooltip said this is the criteria.
![Screen Shot 2020-03-18 at 14 53 23](https://user-images.githubusercontent.com/26707584/76967875-48d8d680-6928-11ea-9730-e5c153f6e1c5.png)

Then in the querybuilder verified that the data is there. 
https://iati.cloud/search/activity?q=reporting_org_ref:(XM-DAC-41121) AND humanitarian:(1)&fl=location_*,title_*&wt=json&rows=5000

Checked if srsName is a required attribute for field location_point_pos:
http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/location/point/





[MLT-843]: https://zimmermanzimmerman.atlassian.net/browse/MLT-843